### PR TITLE
Extend AI trivia game

### DIFF
--- a/features/tba/AiGame.tsx
+++ b/features/tba/AiGame.tsx
@@ -70,8 +70,10 @@ export function AiGame() {
         if (playerHP <= 0) setWinner('AI');
         else if (aiHP <= 0) setWinner('Player');
         else if (index >= questions.length && questions.length > 0) {
-            if (playerHP === aiHP) setWinner('Draw');
-            else setWinner(playerHP > aiHP ? 'Player' : 'AI');
+            setLoading(true);
+            getTriviaQuestions({ amount: 5, difficulty: 'easy' })
+                .then((qs) => setQuestions((prev) => [...prev, ...qs]))
+                .finally(() => setLoading(false));
         }
     }, [playerHP, aiHP, index, questions.length]);
 


### PR DESCRIPTION
## Summary
- keep playing when questions run out
- refresh questions in batches of five

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e898cccac8331a45b7af44c4ef16f