### PR TITLE
Disable category change briefly

### DIFF
--- a/features/tba/AiGame.tsx
+++ b/features/tba/AiGame.tsx
@@ -93,7 +93,7 @@ export function AiGame() {
     }, [playerHP, aiHP, index, questions.length]);
 
     useEffect(() => {
-        if (questions[index]) {
+        if (questions.length > 0) {
             setChangeCategoryDisabled(true);
             const timer = setTimeout(() => setChangeCategoryDisabled(false), 6000);
             return () => clearTimeout(timer);
@@ -193,7 +193,7 @@ export function AiGame() {
             <QuestionCard question={current} onAnswer={handleAnswer} disabled={answerLocked} />
             <div className="flex flex-row justify-center gap-4">
                 <button
-                    className="text-white bg-yellow-600 hover:bg-yellow-500 transition-colors duration-300 px-2 py-1 rounded-lg text-sm disabled:opacity-50"
+                    className={`${changeCategoryDisabled ? `text-slate-300 bg-stone-600` : `text-white bg-yellow-600`} ${!changeCategoryDisabled && `hover:bg-yellow-500 transition-colors duration-300`} px-2 py-1 rounded-lg text-sm disabled:opacity-50`}
                     onClick={handleChangeCategory}
                     disabled={changeCategoryDisabled}
                 >


### PR DESCRIPTION
## Summary
- disable the "Change Category" button for 6 seconds whenever a new question is shown

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eae164d508331bec964dd702a5c43